### PR TITLE
Fix bug where integers weren't validating

### DIFF
--- a/p5-Cikl/lib/Cikl/DataTypes/Integer.pm
+++ b/p5-Cikl/lib/Cikl/DataTypes/Integer.pm
@@ -3,16 +3,12 @@ use strict;
 use warnings;
 use namespace::autoclean;
 use Mouse::Util::TypeConstraints;
-use Scalar::Util qw/looks_like_number/;
-
+use constant IS_NUM_RE => qr/^\d+$/;
 subtype "Cikl::DataTypes::Integer", 
   as 'Int',
   where { 
     my $v = $_; 
-    return(
-      (looks_like_number($v) > 1) # returns 1 if it's a string, > 1 if it is a number
-      && ($v == int($v)));  # If it is a number, then check to see if our value 
-                            # is actually an integer.
+    return (defined($v) && ($v =~ &IS_NUM_RE));
   };
 
 coerce 'Cikl::DataTypes::Integer',

--- a/p5-Cikl/t/Cikl/DataTypes/Integer.t
+++ b/p5-Cikl/t/Cikl/DataTypes/Integer.t
@@ -9,14 +9,19 @@ use Cikl::DataTypes::Integer;
 
 sub testing_class { "Cikl::DataTypes::Integer"; }
 
-sub test_validation : Test(5) {
+sub test_validation : Test(9) {
   my $self = shift;
   my $type = $self->get_constraint();
   ok($type->check(0), "0 is a valid Integer");
   ok($type->check(1), "1 is a valid Integer");
-  ok(!$type->check("0"), "'0' is not a valid Integer");
-  ok(!$type->check("73"), "'73' is not a valid Integer");
+  ok($type->check("0"), "'0' is a valid Integer");
+  ok($type->check("73"), "'73' is a valid Integer");
+
   ok(!$type->check("1.7"), "'1.7' is not a valid Integer");
+  ok(!$type->check("asdf"), "'asdf' is not a valid Integer");
+  ok(!$type->check(-5), "-5 is not a valid Integer");
+  ok(!$type->check("-5"), "'-5' is not a valid Integer");
+  ok(!$type->check(undef), "undef is not a valid Integer");
 }
 
 sub test_coercion : Test(5) {


### PR DESCRIPTION
- Remove usage of looks_like_number, as the behavior has changed as of
  Scalar::Util 1.39.
